### PR TITLE
Fixes to protection levels & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ for try await message in webSocket.messages {
 }
 
 // Observe state changes
-for try await event in webSocket.stateEvents {
+for await event in webSocket.stateEvents {
     switch event {
     case .connecting:
         print("The WebSocket is connecting...")
@@ -56,7 +56,7 @@ for try await event in webSocket.stateEvents {
 }
 
 // Disconnect the socket
-try webSocket.disconnect()
+try await webSocket.disconnect()
 ```
 
 ### Heartbeats

--- a/Sources/SwiftWebSocket/Models.swift
+++ b/Sources/SwiftWebSocket/Models.swift
@@ -46,7 +46,7 @@ extension WebSocket {
         ///
         /// If the message is a data message, the data will be used as-is. If the message is a string message,
         /// the string will be converted to data using UTF-8 before decoding it.
-        func decode<T, Decoder>(
+        public func decode<T, Decoder>(
             _ type: T.Type,
             decoder: Decoder = JSONDecoder()
         ) throws -> T where T: Decodable, Decoder: TopLevelDecoder, Decoder.Input == Data {

--- a/Sources/SwiftWebSocket/ReconnectableWebSocket.swift
+++ b/Sources/SwiftWebSocket/ReconnectableWebSocket.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-actor ReconnectableWebSocket {
+public actor ReconnectableWebSocket {
     /// A stream of messages received by the socket.
     ///
     /// This stream will only finish when ReconnectableWebSocket deinitializes.

--- a/Sources/SwiftWebSocket/ReconnectableWebSocket.swift
+++ b/Sources/SwiftWebSocket/ReconnectableWebSocket.swift
@@ -40,7 +40,7 @@ public actor ReconnectableWebSocket {
     ///   - heartbeats: Whether to send heartbeats after connecting.
     ///   - connector: A closure that returns a URLRequest used to connect the WebSocket. This closure will be called
     ///                every time the web WebSocket connects.
-    init(
+    public init(
         urlSession: URLSession = URLSession.shared,
         heartbeats: WebSocket.Heartbeats = .disabled,
         connector: @escaping () -> URLRequest,

--- a/Sources/SwiftWebSocket/WebSocket.swift
+++ b/Sources/SwiftWebSocket/WebSocket.swift
@@ -114,7 +114,7 @@ public actor WebSocket {
     ///   - reason: Optional further information to explain the closing.
     ///
     /// - Throws WebSocketError.notConnected when the WebSocket is not connected.
-    func disconnect(closeCode: URLSessionWebSocketTask.CloseCode = .normalClosure, reason: String? = nil) async throws {
+    public func disconnect(closeCode: URLSessionWebSocketTask.CloseCode = .normalClosure, reason: String? = nil) async throws {
         guard state == .connected else {
             throw WebSocketError.notConnected
         }


### PR DESCRIPTION
@wvteijlingen 

This was supposed to be multiple PRs but my main branch is synced here so it has all my commits.

These are a couple of issues i've noticed while using this package.
Some things aren't exposed because they weren't marked "public", `webSocket.stateEvents` is not throwable but it has "try" in readme etc.

Nothing else changed, nothing else added, api is the same.