### PR TITLE
Package min version update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftWebSocket",
     platforms: [
         .macOS(.v13),
-        .iOS(.v15),
+        .iOS(.v16),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
Duration has a minimum available version: iOS 16. So raised the SPM minimum version.